### PR TITLE
Implement comment-filter-search extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# vsc_improve_search_command
-vscode basic search commands extensions
+# Comment Filter Search
+
+This extension removes any search results that are entirely comment lines. Toggle the behaviour with the `commentFilterSearch.enabled` setting in your user or workspace settings.
+
+When enabled, it replaces the built‑in file search provider with one that uses VS Code's bundled ripgrep and skips lines detected as comments.

--- a/lib/comment-utils.js
+++ b/lib/comment-utils.js
@@ -1,0 +1,7 @@
+function isCommentLine(line) {
+    return /^\s*(?:\/\/|#|\/\*|\*|<!--|--|;|\')/.test(line);
+}
+
+module.exports = {
+    isCommentLine
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "comment-filter-search",
+  "displayName": "Comment Filter Search",
+  "description": "Filters out comment lines from search results when enabled.",
+  "version": "0.0.1",
+  "publisher": "example",
+  "engines": {
+    "vscode": "^1.74.0"
+  },
+  "activationEvents": [
+    "*"
+  ],
+  "main": "./src/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "Comment Filter Search",
+      "properties": {
+        "commentFilterSearch.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable filtering of comment lines in search results"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "test": "node ./test/test.js"
+  },
+  "dependencies": {
+    "@types/node": "^24.1.0",
+    "vscode": "^1.1.37",
+    "vscode-ripgrep": "^1.13.2"
+  }
+}

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,0 +1,82 @@
+const vscode = require('vscode');
+const cp = require('child_process');
+const path = require('path');
+const readline = require('readline');
+const { rgPath } = require('vscode-ripgrep');
+const { isCommentLine } = require('../lib/comment-utils');
+
+function createProvider() {
+    return {
+        provideTextSearchResults(query, options, progress, token) {
+            return new Promise((resolve) => {
+                const folder = options.folder.fsPath;
+                const args = [
+                    '--line-number', '--column', '--color', 'never'
+                ];
+                if (!query.isRegExp) {
+                    args.push('-F');
+                }
+                if (query.isCaseSensitive) {
+                    args.push('-s');
+                }
+                args.push(query.pattern);
+                args.push(folder);
+
+                const rg = cp.spawn(rgPath, args, { cwd: folder });
+                const rl = readline.createInterface({ input: rg.stdout });
+
+                rl.on('line', (data) => {
+                    const parts = data.split(':');
+                    if (parts.length < 4) {
+                        return;
+                    }
+                    const file = parts.shift();
+                    const lineStr = parts.shift();
+                    const colStr = parts.shift();
+                    const text = parts.join(':');
+                    if (isCommentLine(text)) {
+                        return;
+                    }
+                    const line = parseInt(lineStr, 10) - 1;
+                    const col = parseInt(colStr, 10) - 1;
+                    const uri = vscode.Uri.file(path.join(folder, file));
+                    const range = new vscode.Range(line, col, line, col + query.pattern.length);
+                    progress.report({
+                        uri,
+                        ranges: range,
+                        preview: { text, matches: new vscode.Range(0, col, 0, col + query.pattern.length) }
+                    });
+                });
+                rg.on('close', () => resolve({ limitHit: false }));
+            });
+        }
+    };
+}
+
+function activate(context) {
+    let registration;
+    function updateRegistration() {
+        const config = vscode.workspace.getConfiguration('commentFilterSearch');
+        const enabled = config.get('enabled');
+        if (enabled && !registration) {
+            registration = vscode.workspace.registerTextSearchProvider('file', createProvider());
+        } else if (!enabled && registration) {
+            registration.dispose();
+            registration = undefined;
+        }
+    }
+    updateRegistration();
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(e => {
+        if (e.affectsConfiguration('commentFilterSearch.enabled')) {
+            updateRegistration();
+        }
+    }));
+}
+
+function deactivate() {}
+
+module.exports = {
+    activate,
+    deactivate,
+    isCommentLine
+};

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const { isCommentLine } = require('../lib/comment-utils');
+
+// basic cases
+assert.ok(isCommentLine('// foo'));
+assert.ok(isCommentLine('# bar'));
+assert.ok(isCommentLine('  /* baz */'));
+assert.ok(isCommentLine('<!-- html -->'));
+assert.ok(!isCommentLine('const x = 1; // inline comment'));
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add simple VS Code extension that registers a text search provider to filter comment lines
- document usage in README
- update provider to use VS Code's bundled ripgrep
- export utility to detect comments and add tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cecae24a8832f96350d681d0c738f